### PR TITLE
Don't check for cofactor when unpacking PublicKey

### DIFF
--- a/benches/main.rs
+++ b/benches/main.rs
@@ -86,9 +86,13 @@ fn criterion_kiltz_vahlis_one_benchmark(criterion: &mut Criterion) {
 
     let (pk, sk) = setup(&mut rng);
     let usk = extract_usk(&pk, &sk, &kid, &mut rng);
+    let ppk = pk.to_bytes();
 
     let (c, _k) = encrypt(&pk, &kid, &mut rng);
 
+    criterion.bench_function("kiltz_vahlis_one unpack_pk", |b| {
+        b.iter(|| PublicKey::from_bytes(&ppk))
+    });
     criterion.bench_function("kiltz_vahlis_one setup", |b| {
         let mut rng = rand::thread_rng();
         b.iter(|| setup(&mut rng))


### PR DESCRIPTION
Also adds a benchmark.  Increases performance by 10x (see below.)
To mount any attack using the cofactor an attacker must be able to
manipulate the public parameters.  But then an attacker can simply use
parameters they generated themselves.  Thus the check against the
cofactor is superfluous.

The difference in performance is significant:

```
kiltz_vahlis_one unpack_pk
                        time:   [30.831 ms 30.914 ms 31.013 ms]
                        change: [-92.091% -92.008% -91.941%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 6 outliers among 100 measurements (6.00%)
  1 (1.00%) high mild
  5 (5.00%) high severe
```